### PR TITLE
Honor XDG env vars on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Index data stored in:
 - macOS: `~/Library/Application Support/ygrep/indexes/`
 - Linux: `~/.local/share/ygrep/indexes/`
 
+XDG environment variables (`XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `XDG_RUNTIME_DIR`) are honored on all platforms, including macOS.
+
 ## Upgrading
 
 ```bash

--- a/crates/ygrep-cli/src/commands/indexes.rs
+++ b/crates/ygrep-cli/src/commands/indexes.rs
@@ -4,6 +4,12 @@ use std::path::PathBuf;
 
 /// Get the indexes directory
 fn get_indexes_dir() -> Result<PathBuf> {
+    // Honor XDG_DATA_HOME if set (even on macOS)
+    if let Ok(xdg_data) = std::env::var("XDG_DATA_HOME") {
+        if !xdg_data.is_empty() {
+            return Ok(PathBuf::from(xdg_data).join("ygrep").join("indexes"));
+        }
+    }
     let data_dir = dirs::data_dir()
         .or_else(|| dirs::home_dir().map(|h| h.join(".local/share")))
         .context("Could not determine data directory")?;

--- a/crates/ygrep-core/src/config.rs
+++ b/crates/ygrep-core/src/config.rs
@@ -308,6 +308,12 @@ impl Default for OutputConfig {
 }
 
 fn default_data_dir() -> PathBuf {
+    // Honor XDG_DATA_HOME if set (even on macOS)
+    if let Ok(xdg_data) = std::env::var("XDG_DATA_HOME") {
+        if !xdg_data.is_empty() {
+            return PathBuf::from(xdg_data).join("ygrep");
+        }
+    }
     dirs::data_dir()
         .unwrap_or_else(|| PathBuf::from("~/.local/share"))
         .join("ygrep")
@@ -316,8 +322,8 @@ fn default_data_dir() -> PathBuf {
 impl Config {
     /// Load config from default locations (in order of precedence):
     /// 1. $PWD/.ygrep.toml
-    /// 2. $XDG_CONFIG_HOME/ygrep/config.toml
-    /// 3. ~/.config/ygrep/config.toml
+    /// 2. $XDG_CONFIG_HOME/ygrep/config.toml (if XDG_CONFIG_HOME is set)
+    /// 3. Platform default config dir (~/Library/Application Support on macOS, ~/.config on Linux)
     /// 4. Built-in defaults
     pub fn load() -> Self {
         // Try project-level config
@@ -327,7 +333,19 @@ impl Config {
             }
         }
 
-        // Try user-level config
+        // Try XDG_CONFIG_HOME first (even on macOS)
+        if let Ok(xdg_config) = std::env::var("XDG_CONFIG_HOME") {
+            if !xdg_config.is_empty() {
+                let config_path = PathBuf::from(&xdg_config).join("ygrep").join("config.toml");
+                if let Ok(content) = std::fs::read_to_string(&config_path) {
+                    if let Ok(config) = toml::from_str(&content) {
+                        return config;
+                    }
+                }
+            }
+        }
+
+        // Try platform default config dir
         if let Some(config_dir) = dirs::config_dir() {
             let config_path = config_dir.join("ygrep").join("config.toml");
             if let Ok(content) = std::fs::read_to_string(&config_path) {
@@ -355,6 +373,12 @@ impl Config {
 }
 
 fn default_socket_path() -> PathBuf {
+    // Honor XDG_RUNTIME_DIR if set (even on macOS)
+    if let Ok(xdg_runtime) = std::env::var("XDG_RUNTIME_DIR") {
+        if !xdg_runtime.is_empty() {
+            return PathBuf::from(xdg_runtime).join("ygrep").join("ygrep.sock");
+        }
+    }
     if let Some(runtime_dir) = dirs::runtime_dir() {
         runtime_dir.join("ygrep").join("ygrep.sock")
     } else if let Some(home) = dirs::home_dir() {


### PR DESCRIPTION
Hi, and thanks for this project!

On macOS, the `dirs` crate returns `~/Library/Application Support` regardless of whether XDG environment variables are set. This can be annoying for users (like me) who prefer keeping dotfiles/config in `~/.local/share` and `~/.config` across all platforms.

This PR checks for `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and `XDG_RUNTIME_DIR` before falling back to the dirs crate defaults. The behavior is unchanged if those variables aren't set.

Changes:

- `config.rs`: check XDG vars in `default_data_dir()`, `Config::load()`, and `default_socket_path()`
- `commands/indexes.rs`: check `XDG_DATA_HOME` in `get_indexes_dir()`
- `README.md`: document XDG support
