### PR TITLE
core: retry transient writer lock contention in workspace indexing

### DIFF
--- a/crates/ygrep-core/src/lib.rs
+++ b/crates/ygrep-core/src/lib.rs
@@ -36,6 +36,10 @@ use std::sync::Arc;
 #[cfg(feature = "embeddings")]
 const EMBEDDING_DIM: usize = 384;
 
+/// Retry budget for transient writer contention.
+const WRITER_RETRY_MAX_ATTEMPTS: usize = 4;
+const WRITER_RETRY_BASE_DELAY_MS: u64 = 100;
+
 /// Sender for routing log messages (e.g. to dashboard TUI instead of stderr)
 pub type LogSender = std::sync::mpsc::Sender<String>;
 
@@ -245,6 +249,60 @@ impl Workspace {
         }
     }
 
+    fn is_transient_writer_error(err: &YgrepError) -> bool {
+        match err {
+            YgrepError::Index(tantivy::TantivyError::LockFailure(
+                tantivy::directory::error::LockError::LockBusy,
+                _,
+            )) => true,
+            YgrepError::Index(tantivy::TantivyError::OpenWriteError(
+                tantivy::directory::error::OpenWriteError::FileAlreadyExists(_),
+            )) => true,
+            _ => {
+                let msg = err.to_string();
+                msg.contains("Lockfile")
+                    || msg.contains("LockBusy")
+                    || msg.contains("OpenWriteError(FileAlreadyExists")
+            }
+        }
+    }
+
+    fn with_writer_retry<T, F>(&self, op_name: &str, mut op: F) -> Result<T>
+    where
+        F: FnMut() -> Result<T>,
+    {
+        let mut last_err = None;
+        for attempt in 0..WRITER_RETRY_MAX_ATTEMPTS {
+            match op() {
+                Ok(value) => return Ok(value),
+                Err(err)
+                    if Self::is_transient_writer_error(&err)
+                        && attempt + 1 < WRITER_RETRY_MAX_ATTEMPTS =>
+                {
+                    let wait_ms = WRITER_RETRY_BASE_DELAY_MS * (1u64 << attempt);
+                    tracing::debug!(
+                        "Transient writer contention during {} (attempt {}/{}), retrying in {}ms: {}",
+                        op_name,
+                        attempt + 1,
+                        WRITER_RETRY_MAX_ATTEMPTS,
+                        wait_ms,
+                        err
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(wait_ms));
+                    last_err = Some(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            YgrepError::Search(format!(
+                "Transient writer retries exhausted for {}",
+                op_name
+            ))
+        }))
+    }
+
     /// Index all files in the workspace (text-only by default, fast)
     pub fn index_all(&self) -> Result<IndexStats> {
         self.index_all_with_options(false)
@@ -258,8 +316,9 @@ impl Workspace {
         self.vector_index.clear();
 
         // Phase 1: Index all files with BM25 (fast)
-        let indexer =
-            index::Indexer::new(self.config.indexer.clone(), self.index.clone(), &self.root)?;
+        let indexer = self.with_writer_retry("index_all/indexer_open", || {
+            index::Indexer::new(self.config.indexer.clone(), self.index.clone(), &self.root)
+        })?;
 
         let mut walker = fs::FileWalker::new(self.root.clone(), self.config.indexer.clone())?;
 
@@ -519,8 +578,9 @@ impl Workspace {
         let mut indexed_map = self.build_indexed_files_map();
 
         // Create indexer (does NOT clear vector index)
-        let indexer =
-            index::Indexer::new(self.config.indexer.clone(), self.index.clone(), &self.root)?;
+        let indexer = self.with_writer_retry("index_incremental/indexer_open", || {
+            index::Indexer::new(self.config.indexer.clone(), self.index.clone(), &self.root)
+        })?;
 
         let mut walker = fs::FileWalker::new(self.root.clone(), self.config.indexer.clone())?;
 
@@ -839,11 +899,13 @@ impl Workspace {
             .get_field("path")
             .map_err(|_| YgrepError::Config("path field not found in schema".to_string()))?;
 
-        let term = Term::from_field_text(path_field, &relative_path);
-
-        let mut writer = self.index.writer::<tantivy::TantivyDocument>(50_000_000)?;
-        writer.delete_term(term);
-        writer.commit()?;
+        self.with_writer_retry("delete_file", || {
+            let term = Term::from_field_text(path_field, &relative_path);
+            let mut writer = self.index.writer::<tantivy::TantivyDocument>(50_000_000)?;
+            writer.delete_term(term);
+            writer.commit()?;
+            Ok(())
+        })?;
 
         tracing::debug!("Deleted from index: {}", path.display());
         Ok(())
@@ -889,10 +951,11 @@ impl Workspace {
     /// Index or re-index a single file with optional semantic indexing (for incremental updates)
     #[allow(unused_variables)]
     pub fn index_file_with_options(&self, path: &Path, with_embeddings: bool) -> Result<()> {
-        // Create indexer and index the file
-        let indexer =
-            index::Indexer::new(self.config.indexer.clone(), self.index.clone(), &self.root)?;
-        self.index_file_with_indexer(&indexer, path, with_embeddings)
+        self.with_writer_retry("index_file_with_options", || {
+            let indexer =
+                index::Indexer::new(self.config.indexer.clone(), self.index.clone(), &self.root)?;
+            self.index_file_with_indexer(&indexer, path, with_embeddings)
+        })
     }
 
     /// Index or re-index a single file using an existing Indexer (avoids lock churn)
@@ -1007,6 +1070,7 @@ fn hash_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tantivy::directory::error::{LockError, OpenWriteError};
     use tempfile::tempdir;
 
     #[test]
@@ -1063,5 +1127,22 @@ mod tests {
         assert!(result.hits.iter().any(|h| h.path.contains("hello")));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_transient_writer_error_detection() {
+        let lock_busy = YgrepError::Index(tantivy::TantivyError::LockFailure(
+            LockError::LockBusy,
+            None,
+        ));
+        assert!(Workspace::is_transient_writer_error(&lock_busy));
+
+        let file_exists = YgrepError::Index(tantivy::TantivyError::OpenWriteError(
+            OpenWriteError::FileAlreadyExists(std::path::PathBuf::from("segment.tmp")),
+        ));
+        assert!(Workspace::is_transient_writer_error(&file_exists));
+
+        let non_transient = YgrepError::Config("not transient".to_string());
+        assert!(!Workspace::is_transient_writer_error(&non_transient));
     }
 }


### PR DESCRIPTION
## Summary

This PR reduces transient writer lock failures during concurrent indexing/watch activity by adding retry-with-backoff around workspace write paths.

## What changed

- Added a shared retry helper for transient writer contention in `Workspace`.
- Classified transient errors as:
  - Tantivy `LockFailure(LockBusy, ..)`
  - Tantivy `OpenWriteError(FileAlreadyExists(..))`
  - string fallbacks for lock/open-write contention messages
- Applied retry logic to write-heavy paths:
  - `index_all_with_options()`
  - `index_incremental_with_options()`
  - `index_file_with_options()`
  - `delete_file()`
- Added unit test for transient error classification.

## Why

Under heavy concurrent write pressure (`watch` + repeated `index`), ygrep can fail with lock contention.
This PR does not fully serialize writers, but it substantially reduces failure frequency by retrying transient contention with exponential backoff.

## Repro and stress tests

I compared upstream vs patched binaries using the same local stress harness and parameters.

### Scenario A: index swarm (heavy)
- Parameters: `workers=10`, `loops=40`, `sleep=0.02`
- Upstream:
  - `lockbusy_lines=596`
  - `failed_incremental_lines=260`
- Patched:
  - `lockbusy_lines=210`
  - `failed_incremental_lines=81`

### Scenario B: index swarm (moderate)
- Parameters: `workers=4`, `loops=30`, `sleep=0.03`
- Upstream:
  - `lockbusy_lines=82`
  - `failed_incremental_lines=41`
- Patched:
  - `lockbusy_lines=12`
  - `failed_incremental_lines=5`

### Scenario C: dual watch + churn + index storm
- Upstream:
  - `lockbusy_lines=1`
- Patched:
  - `lockbusy_lines=0`

## Scope and limitations

- This PR improves contention handling but does not guarantee zero lock errors under extreme parallel write load.
- It is a targeted hardening step with low behavioral risk and measurable reduction in failures.

## Future improvements

1. Global single-writer guard per `index_path`
- Before any write path (`index`, watch update, `delete`), acquire a process-local mutex keyed by `index_path`.
- This prevents concurrent `IndexWriter::new()` in the same process, which is the main lock contention source.

2. Reuse a single `Indexer` in watch/dashboard
- Avoid creating a new `Indexer` per file event.
- Keep one writer/indexer for event batches (or watcher lifecycle) and commit in batches.
- This reduces lock churn and race windows.

3. Event debounce + batch apply
- Do not write on every single fs event.
- Buffer events for 300-1000ms and apply one transaction:
  - dedupe `Changed/Deleted` by path
  - single commit per batch
- This lowers writer pressure during git/zip/rename storms.
